### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage
 -----
 
 Add FSMState field to your model
+
     from django_fsm.db.fields import FSMField, transition
 
     class BlogPost(models.Model):


### PR DESCRIPTION
It just makes the first example in the "Usage" section display correctly by adding a blank line.
