### PR TITLE
change length CharField BlogPostStatus.name in tests

### DIFF
--- a/django_fsm/tests.py
+++ b/django_fsm/tests.py
@@ -118,7 +118,7 @@ class DocumentTest(TestCase):
 
 
 class BlogPostStatus(models.Model):
-    name = models.CharField(max_length=3, unique=True)
+    name = models.CharField(max_length=10, unique=True)
     objects = models.Manager()
 
     @transition(source='new', target='published')


### PR DESCRIPTION
The tests use values longer than 3, resulting in test failures.

At least PostgreSQL complains loudly when a value doesn't fit into the varchar:

```
======================================================================
ERROR: test_unknow_transition_fails (django_fsm.tests.BlogPostWithFKStateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/benjamin/projects/django-fsm/django_fsm/tests.py", line 145, in setUp
    BlogPostStatus.objects.create(name="published")
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/manager.py", line 137, in create
    return self.get_query_set().create(**kwargs)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/query.py", line 377, in create
    obj.save(force_insert=True, using=self.db)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/base.py", line 463, in save
    self.save_base(using=using, force_insert=force_insert, force_update=force_update)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/base.py", line 551, in save_base
    result = manager._insert([self], fields=fields, return_id=update_pk, using=using, raw=raw)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/manager.py", line 203, in _insert
    return insert_query(self.model, objs, fields, **kwargs)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/query.py", line 1576, in insert_query
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/models/sql/compiler.py", line 910, in execute_sql
    cursor.execute(sql, params)
  File "/home/benjamin/.dotfiles/buildout/eggs/Django-1.4.1-py2.7.egg/django/db/backends/postgresql_psycopg2/base.py", line 52, in execute
    return self.cursor.execute(query, args)
DatabaseError: value too long for type character varying(3)
```
