### PR TITLE
Readme modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage
 -----
 
 Add FSMState field to your model
+
     from django_fsm.db.fields import FSMField, transition
 
     class BlogPost(models.Model):


### PR DESCRIPTION
adding line 30 to the readme makes `from django_fsm.db.fields import FSMField, transition` show up as part of the code block. The other changes are removing trailing whitespace.
