### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-python:
-    - 2.7
-    - 3.3
 env:
     - $TOX_ENV=py27
     - $TOX_ENV=py33


### PR DESCRIPTION
Simple travis-ci yaml file for continuous integration.

Here it is running off of my fork:
https://travis-ci.org/ftobia/django-fsm

Let me know if you have any issues with this.
