### PR TITLE
Fix FSMIntegerField example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ class BlogPostStateEnum(object):
 class BlogPostWithIntegerField(models.Model):
     state = FSMIntegerField(default=BlogPostStateEnum.NEW)
 
-    @transition(source=BlogPostStateEnum.NEW, target=BlogPostStateEnum.PUBLISHED)
+    @transition(field=state, source=BlogPostStateEnum.NEW, target=BlogPostStateEnum.PUBLISHED)
     def publish(self):
         pass
 ```


### PR DESCRIPTION
Minor documentation fix. The **transition** declaration in the FSMIntegerField example was missing the **field** param.
