### PR TITLE
Remove db_index=True on FSMIntegerField.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ as names, even if field "real" name is used, without _id postfix, as field param
 
 ### Integer Field support 
 
-You can also use `FSMIntegerField`. This is handy when you want to use enum style constants. This field is also `db_index=True` by default for speedy db loookups.
+You can also use `FSMIntegerField`. This is handy when you want to use enum style constants.
 ```python
 class BlogPostStateEnum(object):
     NEW = 10

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -313,11 +313,8 @@ class FSMField(FSMFieldMixin, models.CharField):
 class FSMIntegerField(FSMFieldMixin, models.IntegerField):
     """
     Same as FSMField, but stores the state value in an IntegerField.
-    db_index is True by default.
     """
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('db_index', True)
-        super(FSMIntegerField, self).__init__(*args, **kwargs)
+    pass
 
 
 class FSMKeyField(FSMFieldMixin, models.ForeignKey):


### PR DESCRIPTION
It is generally not a good idea to put indexes on fields without serious reasons. Moreover, index should be a good selector, not returning many items. Creating indexes on status fields is the common example of wrong index usage and thus should not be encouraged by the defaults.

I recommend seeing the talks given by Christophe Pettus and Andrew Godwin at DjangoCon during the past years (including the most recent DjangoCon EU 2014). This thing in particular has been pointed out many times as I remember. Dunno where/when exactly it was mentioned, but I recommend all of their talks anyway (these guys truly do know some shlt about databases).
