### PR TITLE
Document and optimize the new FSMLockMixin code

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -30,11 +30,15 @@ else:
 
 
 class TransitionNotAllowed(Exception):
-    """Raise when a transition is not allowed"""
+    """Raised when a transition is not allowed"""
 
 
 class ConcurrentUpdate(Exception):
-    """Raised when a model can not be saved due to a concurrent update"""
+    """
+    Raised when the transition cannot be executed because the
+    object has become stale (state has been changed since it
+    was fetched from the database).
+    """
 
 
 class Transition(object):
@@ -335,41 +339,74 @@ class FSMKeyField(FSMFieldMixin, models.ForeignKey):
 
 class FSMLockMixin(object):
     """
-    Perform optimistic locking based on fsm state fields
+    Protects a Model from undesirable effects caused by concurrently executed transitions,
+    e.g. running the same transition multiple times at the same time, or running different
+    transitions with the same SOURCE state at the same time.
+
+    This behavior is achieved using an idea based on optimistic locking. No additional
+    version field is required though; the state field(s) is/are used for the tracking.
+    This scheme is not that strict as true *optimistic locking* mechanism, it is however
+    more lightweight - leveraging the specifics of FSM models.
+
+    Instance of a model based on this Mixin will be prevented from saving into DB if any
+    of its state fields (instances of FSMFieldMixin) has been changed since the object
+    was fetched from the database. *ConcurrentUpdate* exception will be raised in such
+    cases.
+
+    For guaranteed protection against such race conditions, make sure:
+    * Your transitions do not have any side effects except for changes in the database,
+    * You always run the save() method on the object within django.db.transaction.atomic()
+    block.
+
+    Following these recommendations, you can rely on FSMLockMixin to cause
+    a rollback of all the changes that have been executed in an inconsistent (out of sync)
+    state, thus practically negating their effect.
     """
     def __init__(self, *args, **kwargs):
         super(FSMLockMixin, self).__init__(*args, **kwargs)
         self._update_initial_state()
 
+    @property
+    def state_fields(self):
+        return filter(
+            lambda field: isinstance(field, FSMFieldMixin),
+            self._meta.fields
+        )
+
     def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update):
-        initial_state = {field: state for field, state in self._initial_fsm_state.items()
-                         if field.model == base_qs.model}
+        # _do_update is called once for each model class in the inheritance hierarchy.
+        # We can only filter the base_qs on state fields (can be more than one!) present in this particular model.
 
-        if not initial_state:
-            """
-            No fsm state on current inheritance level
-            """
-            return super(FSMLockMixin, self)._do_update(
-                base_qs, using, pk_val, values, update_fields, forced_update)
+        # Select state fields to filter on
+        filter_on = filter(lambda field: field.model == base_qs.model, self.state_fields)
 
-        filtered = base_qs.filter(
-            pk=pk_val,
-            **{field.attname: state for field, state in initial_state.items()})
+        # state filter will be used to narrow down the standard filter checking only PK
+        state_filter = {field.attname: self.__initial_states[field.attname] for field in filter_on}
 
-        if not values:
-            updated = int(filtered.exists())
-        else:
-            updated = filtered._update(values) > 0
+        updated = super(FSMLockMixin, self)._do_update(
+            base_qs=base_qs.filter(**state_filter),
+            using=using,
+            pk_val=pk_val,
+            values=values,
+            update_fields=update_fields,
+            forced_update=forced_update
+        )
 
+        # It may happen that nothing was updated in the original _do_update method not because of unmatching state,
+        # but because of missing PK. This codepath is possible when saving a new model instance with *preset PK*.
+        # In this case Django does not know it has to do INSERT operation, so it tries UPDATE first and falls back to
+        # INSERT if UPDATE fails.
+        # Thus, we need to make sure we only catch the case when the object *is* in the DB, but with changed state; and
+        # mimic standard _do_update behavior otherwise. Django will pick it up and execute _do_insert.
         if not updated and base_qs.filter(pk=pk_val).exists():
-            raise ConcurrentUpdate
+            raise ConcurrentUpdate("Cannot save object! The state has been changed since fetched from the database!")
 
         return updated
 
     def _update_initial_state(self):
-        self._initial_fsm_state = {
-            field: getattr(self, field.attname) for field in self._meta.fields
-            if isinstance(field, FSMFieldMixin)}
+        self.__initial_states = {
+            field.attname: field.value_from_object(self) for field in self.state_fields
+        }
 
     def save(self, *args, **kwargs):
         super(FSMLockMixin, self).save(*args, **kwargs)


### PR DESCRIPTION
Hi, what a coincidence, yesterday I just started working on the implementation myself. As I see you have already done it, so I've taken what I think is the best from both versions and pushing it upstream. I think some parts can be done a bit better than in django-optimistic-lock, so I've changed mostly those.

Also, I've documented the code so that it's more clear what it really does.
