### PR TITLE
Add propagate=False property to swallow exceptions after on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ model = BlogPost()
 model.state = 'invalid' # Raises AttributeError
 ```
 
-
 ### `custom` properties
 Custom properties can be added by providing a dictionary to the `custom` keyword on the `transition` decorator.
 ```python
@@ -152,9 +151,11 @@ In case of transition method would raise exception, you can provide specific tar
 @transition(field=state, source='new', target='published', on_error='failed')
 def publish(self):
    """
-   Some exceptio could happends here
+   Some exception could happens here
    """
 ```
+
+To swallow these exceptions after transitioning to the `on_error` state, set `propogate=False`.
 
 ### `state_choices`
 Instead of passing two elements list `choices` you could use three elements `state_choices`,

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -213,6 +213,7 @@ class FSMFieldMixin(object):
 
     def __init__(self, *args, **kwargs):
         self.protected = kwargs.pop('protected', False)
+        self.propogate = kwargs.pop('propogate', True)
         self.transitions = {}  # cls -> (transitions name -> method)
         self.state_proxy = {}  # state -> ProxyClsRef
 
@@ -299,6 +300,8 @@ class FSMFieldMixin(object):
                 signal_kwargs['target'] = exception_state
                 signal_kwargs['exception'] = exc
                 post_transition.send(**signal_kwargs)
+            if not self.propogate:
+                return None
             raise
         else:
             post_transition.send(**signal_kwargs)

--- a/django_fsm/tests/test_propogate_field.py
+++ b/django_fsm/tests/test_propogate_field.py
@@ -1,0 +1,38 @@
+from django.db import models
+from django.test import TestCase
+
+from django_fsm import FSMField, transition
+
+
+class PropogateAccessModel(models.Model):
+    status = FSMField(default='new', propogate=False)
+
+    @transition(field=status, source='new', target='published',
+                on_error='error')
+    def publish(self):
+        raise Exception
+
+    class Meta:
+        app_label = 'django_fsm'
+
+
+class NoPropogateAccessModel(models.Model):
+    status = FSMField(default='new', propogate=False)
+
+    @transition(field=status, source='new', target='published',
+                on_error='error')
+    def publish(self):
+        raise Exception
+
+    class Meta:
+        app_label = 'django_fsm'
+
+class TestPropogateModels(TestCase):
+    def test_propogate(self):
+        instance = NoPropogateAccessModel()
+        self.assertEqual(instance.status, 'new')
+        self.assertNone(instance.publish())
+
+        instance = PropogateAccessModel()
+        self.assertEqual(instance.status, 'new')
+        self.assertRaises(Exception, instance.publish())


### PR DESCRIPTION
When using `on_error` we've found it useful to swallow exceptions since the FSM module is already handling the state transition.  This PR adds an optional `propogate` property to control this.  Behavior defaults to `propogate=True` matching current behavior.

Note: a test was included but it's unclear how to run the suite, so it might not be passing.  Some docs on how to run the tests would be much appreciated.
