### PR TITLE
Override protection mechanism

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -429,8 +429,10 @@ class FSMFieldMixin(object):
         setattr(cls, 'get_available_user_{0}_transitions'.format(self.name),
                 curry(get_available_user_FIELD_transitions, field=self))
 
-        if self.protected and hasattr(self.base_cls, 'refresh_from_db'):  # check for Django prior to v1.8
-            self.base_cls.refresh_from_db = self.override_protection_decorator(self.base_cls.refresh_from_db)
+        if self.protected:
+            if hasattr(self.base_cls, 'refresh_from_db'):  # check for Django prior to v1.8
+                self.base_cls.refresh_from_db = self.override_protection_decorator(self.base_cls.refresh_from_db)
+            self.base_cls.clean_fields = self.override_protection_decorator(self.base_cls.clean_fields)
 
         class_prepared.connect(self._collect_transitions)
 

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -222,7 +222,7 @@ class FSMFieldDescriptor(object):
 
     def __get__(self, instance, type=None):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         return self.field.get_state(instance)
 
     def __set__(self, instance, value):

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -368,17 +368,15 @@ class FSMFieldMixin(object):
 
         if hasattr(self.base_cls, 'refresh_from_db'):  # check for Django prior to v1.8
             original_refresh_from_db = self.base_cls.refresh_from_db
+            field = self
 
             @wraps(original_refresh_from_db)
             def wrapper(self, using=None, fields=None):
-                added_keys = []
-                for field in cls._meta.get_fields():
-                    if isinstance(field, FSMFieldMixin) and field.protected:
-                        key = '_%s_override_protection' % field.name
-                        self.__dict__[key] = True
-                        added_keys.append(key)
+                if field.protected:
+                    key = '_%s_override_protection' % field.name
+                    self.__dict__[key] = True
                 original_refresh_from_db(self, using, fields)
-                for key in added_keys:
+                if field.protected:
                     del self.__dict__[key]
 
             self.base_cls.refresh_from_db = wrapper

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -123,7 +123,7 @@ class override_protection(object):
             available_attrs = WRAPPER_ASSIGNMENTS
         else:
             available_attrs = tuple(a for a in WRAPPER_ASSIGNMENTS if hasattr(func, a))
-        
+
         @wraps(func, assigned=available_attrs)
         def inner(*args, **kwargs):
             with self:

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import unittest
 
-from django_fsm import FSMField, transition
+from django_fsm import FSMField, transition, override_protection
 
 
 class ProtectedAccessModel(models.Model):
@@ -51,3 +51,21 @@ class TestDirectAccessModels(TestCase):
         self.assertEqual(instance.status, 'new')
         instance.full_clean()
         self.assertEqual(instance.status, 'new')
+
+    def test_override_protection_per_field_isolation(self):
+        instance = ProtectedAccessModel()
+        with self.assertRaises(AttributeError):
+            with override_protection(instance, 'status'):
+                instance.another_fsm_field = 'new'
+
+    def test_override_protection_per_field(self):
+        instance = ProtectedAccessModel()
+        with override_protection(instance, 'status'):
+            instance.status = 'change'
+        self.assertEqual(instance.status, 'change')
+
+    def test_override_protection(self):
+        instance = ProtectedAccessModel()
+        with override_protection(instance):
+            instance.status = 'change'
+        self.assertEqual(instance.status, 'change')

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -1,3 +1,6 @@
+import django
+import unittest
+
 from django.db import models
 from django.test import TestCase
 
@@ -19,20 +22,23 @@ class TestDirectAccessModels(TestCase):
     def test_no_direct_access(self):
         instance = ProtectedAccessModel()
         self.assertEqual(instance.status, 'new')
-
+    
         def try_change():
             instance.status = 'change'
-
+    
         self.assertRaises(AttributeError, try_change)
-
+    
         instance.publish()
         instance.save()
         self.assertEqual(instance.status, 'published')
 
+    @unittest.skipIf(django.VERSION < (1, 8), "Django introduced refresh_from_db in 1.8")
     def test_refresh_from_db(self):
         instance = ProtectedAccessModel()
         self.assertEqual(instance.status, 'new')
-
         instance.save()
+        ProtectedAccessModel.objects.all().update(status='change')
+
         instance.refresh_from_db()
-        self.assertEqual(instance.status, 'new')
+        # instance = ProtectedAccessModel.objects.all().get(pk=instance.pk)
+        self.assertEqual(instance.status, 'change')

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -28,3 +28,11 @@ class TestDirectAccessModels(TestCase):
         instance.publish()
         instance.save()
         self.assertEqual(instance.status, 'published')
+
+    def test_refresh_from_db(self):
+        instance = ProtectedAccessModel()
+        self.assertEqual(instance.status, 'new')
+
+        instance.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.status, 'new')

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -44,5 +44,10 @@ class TestDirectAccessModels(TestCase):
         ProtectedAccessModel.objects.all().update(status='change')
 
         instance.refresh_from_db()
-        # instance = ProtectedAccessModel.objects.all().get(pk=instance.pk)
         self.assertEqual(instance.status, 'change')
+
+    def test_model_clean(self):
+        instance = ProtectedAccessModel()
+        self.assertEqual(instance.status, 'new')
+        instance.full_clean()
+        self.assertEqual(instance.status, 'new')

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -12,6 +12,7 @@ from django_fsm import FSMField, transition
 
 class ProtectedAccessModel(models.Model):
     status = FSMField(default='new', protected=True)
+    another_fsm_field = FSMField(default='new', protected=True)
 
     @transition(field=status, source='new', target='published')
     def publish(self):

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -1,8 +1,11 @@
 import django
-import unittest
 
 from django.db import models
 from django.test import TestCase
+try:
+    from django.utils import unittest  # for python2.6
+except ImportError:
+    import unittest
 
 from django_fsm import FSMField, transition
 


### PR DESCRIPTION
Refs #174 
Fix for `refresh_from_db` and `Model.full_clean` with protected fields.

I was unable to found better solution than to wrap `refresh_from_db` to set hidden flag on instance's `__dict__` and look for this flag in protection checking.

Test provided.

**Update:**
Renamed PR as it now solves more general issue.
Moved flags that indicates overriding to a registry under `instance.__dict__`. This looks much better now. Also added context manager for convenient protection overriding.