### PR TITLE
Navigation to related model from FSMKeyField

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -357,7 +357,7 @@ class FSMFieldMixin(object):
         self.base_cls = cls
 
         super(FSMFieldMixin, self).contribute_to_class(cls, name, **kwargs)
-        setattr(cls, self.name, self.descriptor_class(self))
+        setattr(cls, self.name + "_description", self.descriptor_class(self))
         setattr(cls, 'get_all_{0}_transitions'.format(self.name),
                 curry(get_all_FIELD_transitions, field=self))
         setattr(cls, 'get_available_{0}_transitions'.format(self.name),


### PR DESCRIPTION
I renamed the property that allows to retrieve the name of current staqte in case of FSMKeyField is been used. Now it's possible to "navigate" from state to the lookup table instead of making new query to access related model.