### PR TITLE
graph_transitions: fix list of layouts

### DIFF
--- a/django_fsm/management/commands/graph_transitions.py
+++ b/django_fsm/management/commands/graph_transitions.py
@@ -113,6 +113,15 @@ def add_transition(transition_source, transition_target, transition_name, source
     edges.add((source_name, target_name, (('label', transition_name),)))
 
 
+def get_graphviz_layouts():
+    try:
+        import graphviz
+
+        return graphviz.backend.ENGINES
+    except Exception:
+        return {'sfdp', 'circo', 'twopi', 'dot', 'neato', 'fdp', 'osage', 'patchwork'}
+
+
 class Command(BaseCommand):
     requires_system_checks = True
 
@@ -124,7 +133,7 @@ class Command(BaseCommand):
             # NOQA
             make_option('--layout', '-l', action='store', dest='layout', default='dot',
                         help=('Layout to be used by GraphViz for visualization. '
-                              'Layouts: circo dot fdp neato nop nop1 nop2 twopi')),
+                              'Layouts: %s.' % ' '.join(get_graphviz_layouts()))),
         )
         args = "[appname[.model[.field]]]"
     else:
@@ -136,7 +145,7 @@ class Command(BaseCommand):
             parser.add_argument(
                 '--layout', '-l', action='store', dest='layout', default='dot',
                 help=('Layout to be used by GraphViz for visualization. '
-                      'Layouts: circo dot fdp neato nop nop1 nop2 twopi'))
+                      'Layouts: %s.' % ' '.join(get_graphviz_layouts())))
             parser.add_argument('args', nargs='*',
                                 help=('[appname[.model[.field]]]'))
 


### PR DESCRIPTION
Uses `graphviz.backend.ENGINES` to get the available list of
engines/layouts.