### PR TITLE
Fix the tests and update the supported python/django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - 3.7
 
 install:
-    - pip install tox
+    - pip install tox==3.5.2
 
 script:
     - tox --skip-missing-interpreters

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.7"
 
 install:
-    - pip install tox==3.6.0 tox-venv==0.3.1
+    - pip install tox==3.6.0
 
 script:
     - tox --skip-missing-interpreters

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: python
-sudo: false
 
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
 install:
-    - pip install tox==3.5.2
+    - pip install tox==3.6.0
 
 script:
     - tox --skip-missing-interpreters

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.7"
 
 install:
-    - pip install tox==3.6.0
+    - pip install tox==3.6.0 tox-venv==0.3.1
 
 script:
     - tox --skip-missing-interpreters

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,15 @@ matrix:
       - { python: "2.7" }
 
       - { python: "3.4" }
-      - { python: "3.4" }
 
-      - { python: "3.5" }
-      - { python: "3.5" }
-      - { python: "3.5" }
       - { python: "3.5" }
 
       - { python: "3.6" }
-      - { python: "3.6" }
-      - { python: "3.6" }
-      - { python: "3.6" }
 
       - { python: "3.7" }
-      - { python: "3.7" }
-      - { python: "3.7" }
+
+      - install:
+          - pip install tox
 
       - script:
           - tox --skip-missing-interpreters
-
-install:
-    - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,33 @@
 language: python
+cache: pip
+dist: xenial
 
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+sudo: false
+
+matrix:
+    fast_finish: true
+    include:
+      - { python: "2.7" }
+
+      - { python: "3.4" }
+      - { python: "3.4" }
+
+      - { python: "3.5" }
+      - { python: "3.5" }
+      - { python: "3.5" }
+      - { python: "3.5" }
+
+      - { python: "3.6" }
+      - { python: "3.6" }
+      - { python: "3.6" }
+      - { python: "3.6" }
+
+      - { python: "3.7" }
+      - { python: "3.7" }
+      - { python: "3.7" }
+
+      - script:
+          - tox --skip-missing-interpreters
 
 install:
-    - pip install tox==3.6.0
-
-script:
-    - tox --skip-missing-interpreters
+    - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,14 @@
 language: python
-cache: pip
-dist: xenial
 
-sudo: false
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
-matrix:
-    fast_finish: true
-    include:
-      - { python: "2.7" }
+install:
+    - pip install tox==3.6.0 tox-travis==0.11
 
-      - { python: "3.4" }
-
-      - { python: "3.5" }
-
-      - { python: "3.6" }
-
-      - { python: "3.7" }
-
-      - install:
-          - pip install tox
-
-      - script:
-          - tox --skip-missing-interpreters
+script:
+    - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 
 install:
     - pip install tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+django-fsm 2.6.1 2018-12-14
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix the travis tests
+- Add compatibility test with python 3.7, remove 2.6 and 3.3
+- Add compatibility test with Django 2.0 and 2.1, remove 1.6, 1.8, 1.9 and 1.10
+
 django-fsm 2.6.0 2017-06-08
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -417,7 +417,5 @@ django-fsm 2.6.0 2017-06-08
 - Fix django 1.11 compatibility
 - Fix TypeError in `graph_transitions` command when using django's lazy translations
 
-.. |Build Status| image:: https://travis-ci.org/kmmbvnr/django-fsm.svg?branch=master
-   :target: https://travis-ci.org/kmmbvnr/django-fsm
-.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
-   :target: https://gitter.im/kmmbvnr/django-fsm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+.. |Build Status| image:: https://travis-ci.org/MDziwny/django-fsm.svg?branch=master
+   :target: https://travis-ci.org/MDziwny/django-fsm/

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django friendly finite state machine support
 ============================================
 
-|Build Status| |Gitter|
+|Build Status|
 
 django-fsm adds simple declarative states management for django models.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django friendly finite state machine support
 ============================================
 
-|Build Status|
+|Build Status| |Gitter|
 
 django-fsm adds simple declarative states management for django models.
 
@@ -408,5 +408,16 @@ your ``INSTALLED_APPS``:
     # Create a PNG image file only for specific model
     $ ./manage.py graph_transitions -o blog_transitions.png myapp.Blog
 
-.. |Build Status| image:: https://travis-ci.org/MDziwny/django-fsm.svg?branch=master
-   :target: https://travis-ci.org/MDziwny/django-fsm/
+Changelog
+---------
+
+django-fsm 2.6.0 2017-06-08
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix django 1.11 compatibility
+- Fix TypeError in `graph_transitions` command when using django's lazy translations
+
+.. |Build Status| image:: https://travis-ci.org/kmmbvnr/django-fsm.svg?branch=master
+   :target: https://travis-ci.org/kmmbvnr/django-fsm
+.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
+   :target: https://gitter.im/kmmbvnr/django-fsm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge

--- a/README.rst
+++ b/README.rst
@@ -408,14 +408,5 @@ your ``INSTALLED_APPS``:
     # Create a PNG image file only for specific model
     $ ./manage.py graph_transitions -o blog_transitions.png myapp.Blog
 
-Changelog
----------
-
-django-fsm 2.6.0 2017-06-08
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- Fix django 1.11 compatibility
-- Fix TypeError in `graph_transitions` command when using django's lazy translations
-
 .. |Build Status| image:: https://travis-ci.org/MDziwny/django-fsm.svg?branch=master
    :target: https://travis-ci.org/MDziwny/django-fsm/

--- a/README.rst
+++ b/README.rst
@@ -417,6 +417,15 @@ django-fsm 2.6.0 2017-06-08
 - Fix django 1.11 compatibility
 - Fix TypeError in `graph_transitions` command when using django's lazy translations
 
+
+django-fsm 2.7.0 2019-02-14
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Add tests for Python 3.7, remove tests for deprecated Python versions (2.6 and 3.3)
+- Add tests for Django 2.0 and 2.1, remove tests for deprecated Django versions (1.6, 1.7, 1.8 and 1.10)
+- Fix the tests on TravisCI
+
+
 .. |Build Status| image:: https://travis-ci.org/kmmbvnr/django-fsm.svg?branch=master
    :target: https://travis-ci.org/kmmbvnr/django-fsm
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg

--- a/django_fsm/tests/test_key_field.py
+++ b/django_fsm/tests/test_key_field.py
@@ -25,7 +25,7 @@ class DBState(models.Model):
 
 
 class FKBlogPost(models.Model):
-    state = FSMKeyField(DBState, default='new', protected=True)
+    state = FSMKeyField(DBState, default='new', protected=True, on_delete=models.PROTECT)
 
     @transition(field=state, source='new', target='published')
     def publish(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except IOError:
 
 setup(
     name='django-fsm',
-    version='2.6.0',
+    version='2.6.1',
     description='Django friendly finite state machine support.',
     author='Mikhail Podgurskiy',
     author_email='kmmbvnr@gmail.com',
@@ -18,6 +18,7 @@ setup(
     zip_safe=False,
     license='MIT License',
     platforms=['any'],
+    install_requires=["django>=1.11"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -25,17 +26,14 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         "Framework :: Django",
-        "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.9",
-        "Framework :: Django :: 1.10",
         "Framework :: Django :: 1.11",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Framework :: Django',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except IOError:
 
 setup(
     name='django-fsm',
-    version='2.6.1',
+    version='2.7.0',
     description='Django friendly finite state machine support.',
     author='Mikhail Podgurskiy',
     author_email='kmmbvnr@gmail.com',

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -39,7 +39,7 @@ class FKApplication(models.Model):
     Student application need to be approved by dept chair and dean.
     Test workflow for FSMKeyField
     """
-    state = FSMKeyField('testapp.DbState', default='new')
+    state = FSMKeyField('testapp.DbState', default='new', on_delete=models.PROTECT)
 
     @transition(field=state, source='new', target='draft')
     def draft(self):

--- a/tests/testapp/tests/test_model_create_with_generic.py
+++ b/tests/testapp/tests/test_model_create_with_generic.py
@@ -20,7 +20,7 @@ class Task(models.Model):
         NEW = 'new'
         DONE = 'done'
 
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT)
     object_id = models.PositiveIntegerField()
     causality = GenericForeignKey('content_type', 'object_id')
     state = FSMField(default=STATE.NEW)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py27-dj{111}
-    py{34,35,36,37}-dj{111,20,21}
+    py{34,35,36,37}-dj{111,20}
+    py{35,36,37}-dj{21}
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,21 @@
 [tox]
 envlist =
-    py26-dj{16}
-    py27-dj{16,18,19,110,111}
-    py33-dj{16,18}
-    py{34,35,36}-dj{18,19,110,111}
+    py27-dj{111}
+    py{34,35,36,37}-dj{111,20,21}
 skipsdist = True
 
 [testenv]
 deps =
-    py26: ipython==2.1.0
-    {py27,py32,py33}: ipython==5.4.1
-    {py34,py35,py36}: ipython==6.1.0
-    dj16: Django==1.6.11
-    dj16: coverage<=3.999
-    dj16: django-guardian==1.3.2
-    dj18: Django==1.8.18
-    dj18: coverage==4.1
-    dj18: django-guardian==1.4.4
-    dj19: Django==1.9.13
-    dj19: coverage==4.1
-    dj19: django-guardian==1.4.4
-    dj110: Django==1.10.7
-    dj110: coverage==4.1
-    dj110: django-guardian==1.4.4
-    dj111: Django==1.11.2
+    {py34,py35,py36,py37}: ipython==6.1.0
+    dj111: Django==1.11.17
     dj111: coverage==4.3.4
     dj111: django-guardian==1.4.8
+    dj20: Django==2.0.9
+    dj20: coverage==4.3.4
+    dj20: django-guardian==1.4.8
+    dj21: Django==2.1.4
+    dj21: coverage==4.3.4
+    dj21: django-guardian==1.4.8
     graphviz==0.7.1
     pep8==1.7.0
     pyflakes==1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,15 @@
 [tox]
 envlist =
-    py27-dj{111}
-    py{34,35,36,37}-dj{111,20}
-    py{35,36,37}-dj{21}
+    py{27,34,35,36,37}-dj111
+    py{34,35,36,37}-dj20
+    py{35,36,37}-dj21
 skipsdist = True
 
 [testenv]
 deps =
-    {py34,py35,py36,py37}: ipython==6.1.0
     dj111: Django==1.11.17
-    dj111: coverage==4.3.4
-    dj111: django-guardian==1.4.8
     dj20: Django==2.0.9
-    dj20: coverage==4.3.4
-    dj20: django-guardian==1.4.8
     dj21: Django==2.1.4
-    dj21: coverage==4.3.4
-    dj21: django-guardian==1.4.8
+    django-guardian==1.4.8
     graphviz==0.7.1
-    pep8==1.7.0
-    pyflakes==1.5.0
-    ipdb==0.8.1
 commands = {posargs:python ./tests/manage.py test}


### PR DESCRIPTION
I've fixed the tests, added new versions of python (3.7) and django (2.0 and 2.1). I've also removed deprecated versions of python (2.6 and 3.3) and django (1.6, 1.7, 1.8 and 1.10).

If you want to merge it into your master branch, I can put back your Travis and Gitter icons.