### PR TITLE
readme: Fix example target states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,12 +234,12 @@ True if the user can perform the transition.
 
 .. code:: python
 
-    @transition(field=state, source='*', target='publish',
+    @transition(field=state, source='*', target='published',
                 permission=lambda instance, user: not user.has_perm('myapp.can_make_mistakes'))
     def publish(self):
         pass
 
-    @transition(field=state, source='*', target='publish',
+    @transition(field=state, source='*', target='removed',
                 permission='myapp.can_remove_post')
     def remove(self):
         pass


### PR DESCRIPTION
Documentation seems of here, especially having `.remove()` got to state `publish[ed]` rather than `removed`. Happy to discuss and adjust. What do you think?

PS: There is one more use of state `published` (with `ed`) further down in the readme, already.