### PR TITLE
docs: Fix simple typo, achived -> achieved

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ django admin.
 
 https://github.com/gadventures/django-fsm-admin
 
-Transition logging support could be achived with help of django-fsm-log
+Transition logging support could be achieved with help of django-fsm-log
 package
 
 https://github.com/gizmag/django-fsm-log


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `achieved` rather than `achived`.

