### PR TITLE
Removed providing_args kwarg from Signal constructor.

### DIFF
--- a/django_fsm/signals.py
+++ b/django_fsm/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.dispatch import Signal
 
-pre_transition = Signal(providing_args=['instance', 'name', 'source', 'target'])
-post_transition = Signal(providing_args=['instance', 'name', 'source', 'target', 'exception'])
+pre_transition = Signal()
+post_transition = Signal()


### PR DESCRIPTION
The providing_args kwarg to the Signal constructor is deprecated as of Django 3.1, since it's being removed in Django 4.0. It was always just informational, so removing it has no affect on the behavior of the signals.