### PR TITLE
Add Mixin that allows refresh_from_db

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -495,6 +495,32 @@ class ConcurrentTransitionMixin(object):
         self._update_initial_state()
 
 
+class FSMModelMixin(object):
+    """
+    Mixin that allows refresh_from_db for models with fsm protected fields
+    """
+
+    def _get_protected_fsm_fields(self):
+        def is_fsm_and_protected(f):
+            return isinstance(f, FSMFieldMixin) and f.protected
+        protected_fields = filter(is_fsm_and_protected, self._meta.concrete_fields)
+        return {f.attname for f in protected_fields}
+
+    def refresh_from_db(self, *args, **kwargs):
+        fields = kwargs.pop("fields", None)
+
+        # Use provided fields, if not set then reload all non-deferred fields.0
+        if not fields:
+            deferred_fields = self.get_deferred_fields()
+            protected_fields = self._get_protected_fsm_fields()
+            skipped_fields = deferred_fields.union(protected_fields)
+
+            fields = [f.attname for f in self._meta.concrete_fields
+                      if f.attname not in skipped_fields]
+
+        kwargs['fields'] = fields
+        super(FSMModelMixin, self).refresh_from_db(*args, **kwargs)
+
 def transition(field, source='*', target=None, on_error=None, conditions=[], permission=None, custom={}):
     """
     Method decorator to mark allowed transitions.

--- a/django_fsm/tests/test_protected_field.py
+++ b/django_fsm/tests/test_protected_field.py
@@ -1,7 +1,10 @@
+import unittest
+
+import django
 from django.db import models
 from django.test import TestCase
 
-from django_fsm import FSMField, transition
+from django_fsm import FSMField, FSMModelMixin, transition
 
 
 class ProtectedAccessModel(models.Model):
@@ -13,6 +16,10 @@ class ProtectedAccessModel(models.Model):
 
     class Meta:
         app_label = 'django_fsm'
+
+
+class RefreshableModel(FSMModelMixin, ProtectedAccessModel):
+    pass
 
 
 class TestDirectAccessModels(TestCase):
@@ -28,3 +35,10 @@ class TestDirectAccessModels(TestCase):
         instance.publish()
         instance.save()
         self.assertEqual(instance.status, 'published')
+
+    @unittest.skipIf(django.VERSION < (1, 8), "Django introduced refresh_from_db in 1.8")
+    def test_refresh_from_db(self):
+        instance = RefreshableModel()
+        instance.save()
+
+        instance.refresh_from_db()


### PR DESCRIPTION
This PR aims to allow `model.refresh_from_db()` for a `model` that contains protected fields. fixes #174 

Inspired by django internal [refresh_from_db](https://github.com/django/django/blob/84ca7b860223d9211976be1a179c727784defc7a/django/db/models/base.py#L633) 