### PR TITLE
Allow deferring FSM fields

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -6,7 +6,9 @@ import inspect
 import sys
 from functools import wraps
 
+import django
 from django.db import models
+from django.db.models.query_utils import DeferredAttribute
 from django.db.models.signals import class_prepared
 from django_fsm.signals import pre_transition, post_transition
 
@@ -268,7 +270,26 @@ class FSMFieldMixin(object):
         return name, path, args, kwargs
 
     def get_state(self, instance):
-        return instance.__dict__[self.name]
+        # The state field may be deferred. We delegate the logic of figuring
+        # this out and loading the deferred field on-demand to Django's
+        # built-in DeferredAttribute class. DeferredAttribute's instantiation
+        # signature changed over time, so we need to check Django version
+        # before proceeding to call DeferredAttribute. An alternative to this
+        # would be copying the latest implementation of DeferredAttribute to
+        # django_fsm, but this comes with the added responsibility of keeping
+        # the copied code up to date.
+        if django.VERSION[:3] >= (3, 0, 0):
+            return DeferredAttribute(self).__get__(instance)
+        elif django.VERSION[:3] >= (2, 1, 0):
+            return DeferredAttribute(self.name).__get__(instance)
+        elif django.VERSION[:3] >= (1, 10, 0):
+            return DeferredAttribute(self.name, model=None).__get__(instance)
+        else:
+            # The field was either not deferred (in which case we can return it
+            # right away) or ir was, but we are running on an unknown version
+            # of Django and we do not know the appropriate DeferredAttribute
+            # interface, and accessing the field will raise KeyError.
+            return instance.__dict__[self.name]
 
     def set_state(self, instance, state):
         instance.__dict__[self.name] = state

--- a/tests/testapp/tests/test_access_deferred_fsm_field.py
+++ b/tests/testapp/tests/test_access_deferred_fsm_field.py
@@ -1,0 +1,32 @@
+from django.db import models
+from django.test import TestCase
+from django_fsm import FSMField, transition, can_proceed
+
+
+class DeferrableModel(models.Model):
+    state = FSMField(default='new')
+
+    @transition(field=state, source='new', target='published')
+    def publish(self):
+        pass
+
+    @transition(field=state, source='+', target='removed')
+    def remove(self):
+        pass
+
+    class Meta:
+        app_label = 'testapp'
+
+
+class Test(TestCase):
+    def setUp(self):
+        DeferrableModel.objects.create()
+        self.model = DeferrableModel.objects.only('id').get()
+
+    def test_usecase(self):
+        self.assertEqual(self.model.state, 'new')
+        self.assertTrue(can_proceed(self.model.remove))
+        self.model.remove()
+
+        self.assertEqual(self.model.state, 'removed')
+        self.assertFalse(can_proceed(self.model.remove))


### PR DESCRIPTION
This commit changes the `FSMFieldMixin.get_state()` method to wrap the
fields with Django's built-in DeferredAttribute descriptor. This
descriptor handles fetching the field value from the database in case it
was deferred before by using `.deferred()` or `.only()` queryset
methods.

Fixes #186