### PR TITLE
Fix refresh_from_db with ConcurrentTransitionMixin

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -485,7 +485,7 @@ class ConcurrentTransitionMixin(object):
         filter_on = filter(lambda field: field.model == base_qs.model, self.state_fields)
 
         # state filter will be used to narrow down the standard filter checking only PK
-        state_filter = dict((field.attname, self.__initial_states[field.attname]) for field in filter_on)
+        state_filter = dict((field.attname, self._fsm_initial_states[field.attname]) for field in filter_on)
 
         updated = super(ConcurrentTransitionMixin, self)._do_update(
             base_qs=base_qs.filter(**state_filter),
@@ -508,12 +508,16 @@ class ConcurrentTransitionMixin(object):
         return updated
 
     def _update_initial_state(self):
-        self.__initial_states = dict(
+        self._fsm_initial_states = dict(
             (field.attname, field.value_from_object(self)) for field in self.state_fields
         )
 
     def save(self, *args, **kwargs):
         super(ConcurrentTransitionMixin, self).save(*args, **kwargs)
+        self._update_initial_state()
+
+    def refresh_from_db(self, *args, **kwargs):
+        super().refresh_from_db(*args, **kwargs)
         self._update_initial_state()
 
 


### PR DESCRIPTION
I've added `ConcurrentTransitionMixin` years ago when `refresh_from_db` did not exist in Django yet.

This PR **fixes the corner case** when `refresh_from_db` is called on a model inheriting `ConcurrentTransitionMixin` and later it is attempted to be saved.

**Current issue explanation**: If the state has been changed in the DB since object initial load (which might have been totally expected and actually the very reason for calling `refresh_from_db`), saving an object will crash even if `refresh_from_db` has been explicitly called after the concurrent state change.