### PR TITLE
Support multiple FSMMeta on a single method

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -502,9 +502,14 @@ def change_state(instance, method, *args, **kwargs):
         for meta, (current_state, next_state) in state_map.items():
             if next_state is not None:
                 if hasattr(next_state, 'get_state'):
-                    next_state = next_state.get_state(
-                        instance, transition, result,
-                        args=args, kwargs=kwargs)
+                    if isinstance(result, dict):
+                        next_state = next_state.get_state(
+                            instance, transition, result[meta.field.name],
+                            args=args, kwargs=kwargs)
+                    else:
+                        next_state = next_state.get_state(
+                            instance, transition, result,
+                            args=args, kwargs=kwargs)
                 meta.field.set_proxy(instance, next_state)
                 meta.field.set_state(instance, next_state)
     except Exception as exc:

--- a/django_fsm/tests/test_multiple_transitions.py
+++ b/django_fsm/tests/test_multiple_transitions.py
@@ -1,0 +1,40 @@
+from django.db import models
+from django.test import TestCase
+
+from django_fsm import FSMField, TransitionNotAllowed, transition, can_proceed
+from django_fsm.signals import pre_transition, post_transition
+
+
+class BlogPost(models.Model):
+    state = FSMField(default='new')
+    state2 = FSMField(default='new2')
+
+    @transition(field=state, source='new', target='published')
+    @transition(field=state2, source='new2', target='published2')
+    def publish(self):
+        pass
+
+    @transition(field=state, source='published', target='hidden')
+    @transition(field=state2, source='published2', target='hidden2')
+    def hide(self):
+        pass
+
+
+class FSMMultpleTransitionTest(TestCase):
+    def setUp(self):
+        self.model = BlogPost()
+
+    def test_known_transition_should_succeed(self):
+        self.assertTrue(can_proceed(self.model.publish))
+        self.model.publish()
+        self.assertEqual(self.model.state, 'published')
+        self.assertEqual(self.model.state2, 'published2')
+
+    def test_unknown_transition_fails_all_conditions_unmet(self):
+        self.assertFalse(can_proceed(self.model.hide))
+        self.assertRaises(TransitionNotAllowed, self.model.hide)
+
+    def test_unknown_transition_fails_partial_conditions_unmet(self):
+        self.model.state = 'published'
+        self.assertFalse(can_proceed(self.model.hide))
+        self.assertRaises(TransitionNotAllowed, self.model.hide)


### PR DESCRIPTION
This resolves #42.

```py
    # example
    @transition(field=state, source='APPROVED', target='REVIEW')
    @transition(field=submission_state, source='DONE', target='WAITING')
    def review(self):
        pass
```