### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/testapp/tests/test_custom_data.py
+++ b/tests/testapp/tests/test_custom_data.py
@@ -32,7 +32,7 @@ class CustomTransitionDataTest(TestCase):
     def test_initial_state(self):
         self.assertEqual(self.model.state, 'new')
         transitions = list(self.model.get_available_state_transitions())
-        self.assertEquals(len(transitions), 1)
+        self.assertEqual(len(transitions), 1)
         self.assertEqual(transitions[0].target, 'published')
         self.assertDictEqual(transitions[0].custom, {'label': 'Publish', 'type': '*'})
 

--- a/tests/testapp/tests/test_permissions.py
+++ b/tests/testapp/tests/test_permissions.py
@@ -22,16 +22,16 @@ class PermissionFSMFieldTest(TestCase):
         self.assertTrue(has_transition_perm(self.model.remove, self.priviledged))
 
         transitions = self.model.get_available_user_state_transitions(self.priviledged)
-        self.assertEquals(set(['publish', 'remove', 'moderate']),
-                          set(transition.name for transition in transitions))
+        self.assertEqual(set(['publish', 'remove', 'moderate']),
+                         set(transition.name for transition in transitions))
 
     def test_unpriviledged_access_prohibited(self):
         self.assertFalse(has_transition_perm(self.model.publish, self.unpriviledged))
         self.assertFalse(has_transition_perm(self.model.remove, self.unpriviledged))
 
         transitions = self.model.get_available_user_state_transitions(self.unpriviledged)
-        self.assertEquals(set(['moderate']),
-                          set(transition.name for transition in transitions))
+        self.assertEqual(set(['moderate']),
+                         set(transition.name for transition in transitions))
 
     def test_permission_instance_method(self):
         self.assertFalse(has_transition_perm(self.model.restore, self.unpriviledged))


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268