### PR TITLE
Implement Transition.__hash__ and __eq__ for 'in' operator

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -123,6 +123,17 @@ class Transition(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return other == self.name
+        if isinstance(other, Transition):
+            return other.name == self.name
+
+        return False
+
 
 def get_available_FIELD_transitions(instance, field):
     """

--- a/django_fsm/tests/test_basic_transitions.py
+++ b/django_fsm/tests/test_basic_transitions.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.test import TestCase
 
-from django_fsm import FSMField, TransitionNotAllowed, transition, can_proceed
+from django_fsm import FSMField, TransitionNotAllowed, transition, can_proceed, Transition
 from django_fsm.signals import pre_transition, post_transition
 
 
@@ -142,6 +142,29 @@ class StateSignalsTests(TestCase):
 class TestFieldTransitionsInspect(TestCase):
     def setUp(self):
         self.model = BlogPost()
+
+    def test_in_operator_for_available_transitions(self):
+        # store the generator in a list, so we can reuse the generator and do multiple asserts
+        transitions = list(self.model.get_available_state_transitions())
+
+        self.assertIn("publish", transitions)
+        self.assertNotIn("xyz", transitions)
+
+        # inline method for faking the name of the transition
+        def publish():
+            pass
+
+        obj = Transition(
+            method=publish,
+            source="",
+            target="",
+            on_error="",
+            conditions="",
+            permission="",
+            custom="",
+        )
+
+        self.assertTrue(obj in transitions)
 
     def test_available_conditions_from_new(self):
         transitions = self.model.get_available_state_transitions()


### PR DESCRIPTION
Hello Folks, 

For managing te state of your models in a Django project this library is a perfect fit. So thanks for providing this excellent library. 

I find myself looping a lot over the results of `get_available_FIELD_transitions` to check if an transition is available. 

Therefore I decided to make the `Transition` object [hashable](https://docs.python.org/3/glossary.html#term-hashable) by implementing  the `__hash__` and `__eq__` methods. 

This adds support for a clean way of checking if a transition is available in a certain context
```python
if 'publish' in blog.get_available_state_transitions():
    do_logic()
```

Looking forward to receive your feedback. 

