### PR TITLE
Add Django 4.0 and 4.1 PyPI classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
These help announce that the project works with the new versions.