### PR TITLE
docs: fix simple typo, exluding -> excluding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ on a model instance with a protected FSMField will cause an exception.
 
 You can use ``*`` for ``source`` to allow switching to ``target`` from any state. 
 
-You can use ``+`` for ``source`` to allow switching to ``target`` from any state exluding ``target`` state.
+You can use ``+`` for ``source`` to allow switching to ``target`` from any state excluding ``target`` state.
 
 ``target`` state
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `excluding` rather than `exluding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md