### PR TITLE
Added quotes around graphviz>=0.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -405,7 +405,7 @@ Drawing transitions
 
 Renders a graphical overview of your models states transitions
 
-You need ``pip install graphviz>=0.4`` library and add ``django_fsm`` to
+You need ``pip install "graphviz>=0.4"`` library and add ``django_fsm`` to
 your ``INSTALLED_APPS``:
 
 .. code:: python


### PR DESCRIPTION
"zsh: 0.4 not found" is the error message returned if quotes aren't added around the package name when it has the ">=" characters on Pip 22.3