### PR TITLE
Preserve chosen "using" DB in ConcurrentTransitionMixin

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -530,7 +530,7 @@ class ConcurrentTransitionMixin(object):
         # INSERT if UPDATE fails.
         # Thus, we need to make sure we only catch the case when the object *is* in the DB, but with changed state; and
         # mimic standard _do_update behavior otherwise. Django will pick it up and execute _do_insert.
-        if not updated and base_qs.filter(pk=pk_val).exists():
+        if not updated and base_qs.filter(pk=pk_val).using(using).exists():
             raise ConcurrentTransition("Cannot save object! The state has been changed since fetched from the database!")
 
         return updated


### PR DESCRIPTION
It's best to use the same DB connection here as well, in order to prevent unexpected results e.g. if read from a read replica that is not synced yet.