### PR TITLE
Fix command for django 4+

### DIFF
--- a/django_fsm/management/commands/graph_transitions.py
+++ b/django_fsm/management/commands/graph_transitions.py
@@ -6,8 +6,11 @@ from itertools import chain
 from django.core.management.base import BaseCommand
 try:
     from django.utils.encoding import force_text
+    _requires_system_checks = True
 except ImportError:  # Django >= 4.0
     from django.utils.encoding import force_str as force_text
+    from django.core.management.base import ALL_CHECKS
+    _requires_system_checks = ALL_CHECKS
 
 from django_fsm import FSMFieldMixin, GET_STATE, RETURN_VALUE
 
@@ -135,7 +138,7 @@ def get_graphviz_layouts():
 
 
 class Command(BaseCommand):
-    requires_system_checks = True
+    requires_system_checks = _requires_system_checks
 
     if not HAS_ARGPARSE:
         option_list = BaseCommand.option_list + (


### PR DESCRIPTION
This PR solve issue #289 

Here is a reference to a related Django issue : https://github.com/pfouque/django-fsm/pull/new/fix_command

Basically 'True' need to be replaced by `__all__` : Django provides a constant but tell me If you prefer to hardcode it (what Django does)

Cf: https://github.com/django/django/commit/c60524c658f197f645b638f9bcc553103bfe2630#diff-b24fd1a4236b2598b0c5de3e4aba7032cecacb4586f5c0082387fc7888993434L225

