### PR TITLE
Convert label to str in graph_transitions.py

### DIFF
--- a/django_fsm/management/commands/graph_transitions.py
+++ b/django_fsm/management/commands/graph_transitions.py
@@ -105,9 +105,9 @@ def generate_dot(fields_data):
 
         final_states = targets - sources
         for name, label in final_states:
-            subgraph.node(name, label=label, shape="doublecircle")
+            subgraph.node(name, label=str(label), shape="doublecircle")
         for name, label in (sources | targets) - final_states:
-            subgraph.node(name, label=label, shape="circle")
+            subgraph.node(name, label=str(label), shape="circle")
             if field.default:  # Adding initial state notation
                 if label == field.default:
                     initial_name = node_name(field, "_initial")


### PR DESCRIPTION
If the label of a state is not a string, trying to add it to the graphviz Graph will fail. This could be the case when using `FSMFieldMixin` instead of directly using `FSMField`.

In my case, I'm using `django-fsm` in combination with `django-enumfields` via a custom class `StateField`, which combines `FSMFieldMixin` with `EnumField`. In this case, the value of the state is not a string but an `Enum`, which will raise an exception when trying to add a label which isn't a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured consistent label types for nodes in transition graphs by converting labels to strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->